### PR TITLE
(#8): increase nrpe check timeout to 30 seconds

### DIFF
--- a/agent/nrpe.ddl
+++ b/agent/nrpe.ddl
@@ -4,7 +4,7 @@ metadata    :name        => "nrpe",
             :license     => "Apache-2.0",
             :version     => "4.0.1",
             :url         => "https://github.com/choria-plugins/nrpe-agent",
-            :timeout     => 5
+            :timeout     => 30
 
 requires :mcollective => "2.2.1"
 


### PR DESCRIPTION
As discussed in issue #8, increase check timeout to 30 seconds.